### PR TITLE
yml changes for ceedling passing

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -6,3 +6,8 @@
     - tests/**
     - -:tests/build/**
 
+:plugins:
+  :load_paths:
+    - "#{Ceedling.load_path}"
+  :enabled:
+    - stdout_pretty_tests_report


### PR DESCRIPTION
This is the changes needed to get the failures status happening locally. It seems currently failures is tied to the stdout plugin.